### PR TITLE
Fix right motor limits mapping

### DIFF
--- a/gbg-freertos/gbg-freertos.ino
+++ b/gbg-freertos/gbg-freertos.ino
@@ -133,8 +133,8 @@
      }
  
      if (abs(rightMotorPower) > 10) {
-       rightMotorRequestedPower = map(rightMotorPower, -100, 100, MAX_BWD_LEFT_MOTOR_POWER, MAX_FWD_LEFT_MOTOR_POWER);
-       rightMotorRequestedPower = constrain(rightMotorRequestedPower, MAX_BWD_LEFT_MOTOR_POWER, MAX_FWD_RIGHT_MOTOR_POWER);
+       rightMotorRequestedPower = map(rightMotorPower, -100, 100, MAX_BWD_RIGHT_MOTOR_POWER, MAX_FWD_RIGHT_MOTOR_POWER);
+       rightMotorRequestedPower = constrain(rightMotorRequestedPower, MAX_BWD_RIGHT_MOTOR_POWER, MAX_FWD_RIGHT_MOTOR_POWER);
      } else {
        rightMotorRequestedPower = 0;
      }


### PR DESCRIPTION
## Summary
- map right motor commands to their dedicated forward/backward limits in the motor drive task
- ensure the right motor constraint uses the right-specific bounds

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d019322bcc832980ec1d788091ee9b